### PR TITLE
Add travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: no
+language: node_js
+node_js:
+- '0.11'
+- '0.10'
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Modeled on UI Tour
 
+![build status](https://travis-ci.org/mozilla/self-repair-server.svg)
+
 ## setup
 
 ```
@@ -56,4 +58,3 @@ Build using webpack
 ## Issues / Bugs
 
 For now, github issues at https://github.com/mozilla/self-repair-server/issues
-

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {},
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Tests are noop\""
   },
   "author": "Gregg Lind <glind@mozilla.com>",
   "license": "MPL 2"


### PR DESCRIPTION
adds a travis.yml file that can be used for continuous integration. Eventually this will be used to initiate auto-deployment to a cdn but for now we'll keep it simple to get it working at all.`