### PR TITLE
add endpoint, region, and cleanup per template in travis docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ deploy:
   secret_access_key:
     secure: b2wz2BN2iRlSmN6FjxhqKcPWeMdR40zlKRRbgu1fNEVczmuesnGh1ZaKwWuPwRlaK7B/LVeqT9eX388OMIOHIlFLnTLbXL0ZD7L/1oqUoYiAtM9QL4BSi0bHdCHqLX5ww78qguZ5HpboknxcmoLUh62Z4xlFdobQoQAC7VoIuOc=
   bucket: org.mozilla.self-repair
+  skip_cleanup: true
+  endpoint: org.mozilla.self-repair.s3-website-us-west-2.amazonaws.com
+  region: us-west-2
   local-dir: repair
   acl: public_read
   on:


### PR DESCRIPTION
per these docs: http://docs.travis-ci.com/user/deployment/s3/

The only way to test this is to land it on master, since we've switched it to only run on master. Forgive the churn.