### PR TITLE
travis before_deploy after_deploy auditing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ addons:
   firefox: "35.0"
 notifications:
   email: false
+
+before_deploy:
+  - touch deploy/releases
+  - date >> deploy/releases
+
 deploy:
   provider: s3
   access_key_id: AKIAJGJURJAHEHGR7WFA


### PR DESCRIPTION
- maybe echo/append to a file in /deploy?  Mail?  send a message?  makes it easy to know the list of releases on a node, and how fast they propogate.

@lonnen, thoughts?
