### PR TITLE
understand all hberror log failures

### DIFF
--- a/test/test-hb-server-up.js
+++ b/test/test-hb-server-up.js
@@ -78,7 +78,10 @@ describe("hb server", function () {
       );
     });
 
-    it("should not accept garbage input", function (done) {
+    // this leads to garbage loglines at
+    // https://input.mozilla.org/en-US/analytics/hberrorlog
+    // but now works properly, fixed, but disabled at  #75
+    it.skip("should not accept garbage input", function (done) {
       let isdone = false;
       let safedone = function (a) {
         if (!isdone) {isdone=true; expect(true).true(); done(a)}
@@ -93,7 +96,7 @@ describe("hb server", function () {
       //  1800
       //);
       cors("https://input.mozilla.org/api/v2/hb/",
-       {garbage: data}).then(
+       {garbage: data()}).then(
         () => safedone(new Error("no garbage!")),
         () => safedone() // should reject, ok
       );


### PR DESCRIPTION
## Type 1:  wrong order

151881 	packet errors 	2015-02-26 10:03:03 	{u'updated_ts': u'updated timestamp is same or older than existing data'}

## Type 2:  Empty POST

151873 	packet errors 	2015-02-26 09:58:06 	{u'question_text': [u'This field is required.'], u'response_version': [u'This field is required.'], u'variation_id': [u'This field is required.'], u'experiment_version': [u'This field is required.'], u'updated_ts': [u'This field is required.'], u'flow_id': [u'This field is required.'], u'person_id': [u'This field is required.'], u'survey_id': [u'This field is required.'], u'question_id': [u'This field is required.']}