### PR TITLE
add max-age 1 minute cache control headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,6 @@ deploy:
   region: us-west-2
   local-dir: deploy
   acl: public_read
+  cache_control: "max-age=60"
   on:
     repo: mozilla/self-repair-server


### PR DESCRIPTION
Rather than making CloudFront responsible for cache time, we can use cache control headers from s3. Amazon's documentation [1] says to prefer the max-age header, so here we'll have travis set up s3 to send a 1 minute max-age header for all the files we push.

[1]http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html