### PR TITLE
Gentler heartbeat geo rollout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "self-repair-server",
-  "version": "0.10.9",
+  "version": "0.11.0",
   "description": "Server package for Mozilla self-repair-server.",
   "main": "",
   "repository": {

--- a/src/common/deploy-geo.js
+++ b/src/common/deploy-geo.js
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*jshint forin:true, noarg:false, noempty:true, eqeqeq:true, bitwise:true,
+  strict:true, undef:true, curly:false, browser:true,
+  unused:true,
+  indent:2, maxerr:50, devel:true, node:true, boss:true, white:true,
+  globalstrict:true, nomen:false, newcap:true, esnext: true, moz: true  */
+
+/*global require, console, exports, geoip_country_code */
+
+// adapted from:
+
+"use strict";
+
+// bascially, if we think it's august 2015, do a special rollout, otherwise,
+// don't.
+
+const geo = require("./geo");
+const fakeUserCountry = () => Promise.resolve("--");
+
+
+`logic
+
+1.  is it august 2015?  If so, answer proporitional to day
+2.  else:  just answer, darn it
+`
+
+var useReal = function (now=new Date(), rng=Math.random()) {
+  var d = now.getDate(),
+      m = now.getMonth(),
+      y = now.getFullYear();
+
+  // false ONLY in 2015/Aug *and* 'too early'
+  let ans = !(y == 2015 && m == 7 && ((d / 30) < rng) );
+
+  return ans
+}
+
+var maybeGetUserCountry = function (real) {
+  if (real === undefined) real = useReal();
+  if (real) return geo.getUserCountry();
+  else return fakeUserCountry();
+}
+
+exports.getUserCountry = maybeGetUserCountry;
+exports.reset = geo.reset;
+exports.useReal = useReal;

--- a/src/common/geo.js
+++ b/src/common/geo.js
@@ -18,7 +18,7 @@
 var $script = require("scriptjs");
 
 var GEO_URL = 'https://geo.mozilla.org/country.js';
-var GEO_CACHE_DURATION = 1000 * 60 * 60 * 24 * 30; // 30 days
+var GEO_CACHE_DURATION = 1000 * 60 * 60 * 24 * (30 + Math.random()); // 30-ish days
 
 function downloadUserCountry() {
   return new Promise(function (resolve, reject) {

--- a/test/common/test-deploy-geo.js
+++ b/test/common/test-deploy-geo.js
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*jshint forin:true, noarg:false, noempty:true, eqeqeq:true, bitwise:true,
+  strict:true, undef:true, curly:false, browser:true,
+  unused:true,
+  indent:2, maxerr:50, devel:true, node:true, boss:true, white:true,
+  globalstrict:true, nomen:false, newcap:true, esnext: true, moz: true,
+  asi: true
+  */
+
+/*global describe, it, require */
+
+/*
+  note: these tests are hard to write / fragile,
+  because they all rely on localStorage being written to in a specific order.
+*/
+
+"use strict";
+
+let { expect } = require("chai");
+let deployGeo = require("../../src/common/deploy-geo");
+let geo = require("../../src/common/geo");
+
+
+require("../utils").shimTodo(it);
+
+var cacheAnswer = function (answer, when) {
+  when = new Date(when || new Date());
+  localStorage.setItem(localStorageKey, answer.toLowerCase());
+  localStorage.setItem('geoLastUpdated', when);
+}
+
+var clearOurKeys = function () {
+  localStorage.removeItem(localStorageKey);
+  localStorage.removeItem('geoLastUpdated');
+};
+
+describe('deployGeo', () => {
+  describe('module', () => {
+    let wanted = ['getUserCountry', 'reset', 'useReal'];
+    it('export keys, as methods', ()=>{
+      expect(deployGeo).keys(wanted);
+      wanted.forEach((k)=>{
+        expect(deployGeo).respondTo(k)
+      })
+    })
+  });
+
+  describe('useReal', () => {
+    it('logic is correct', function () {
+      var real = true;
+      let cases = [
+        ["Oct 04 2015 12:03:09 GMT-0500 (CDT)", 0, "not august", real ],
+        ["Aug 04 2016 12:03:09 GMT-0500 (CDT)", 0, "not 2015", real],
+        ["Aug 04 2015 12:03:09 GMT-0500 (CDT)", 0, "low rng", real ],
+        ["Aug 04 2015 12:03:09 GMT-0500 (CDT)", 1, "right rng", !real ],
+      ]
+
+      cases.forEach(function (t) {
+        let D = new Date(Date.parse(t[0])),
+            rng = t[1],
+            msg = t[2],
+            wanted = t[3];
+
+        expect(deployGeo.useReal(D,rng), msg).to.equal(wanted)
+      })
+    })
+  });
+
+  describe('maybeGetUserCountry', () => {
+    it('false does fake', function (done) {
+        deployGeo.getUserCountry(false).then((ans) => {
+        expect(ans).to.equal("--");
+        done();
+      });
+    })
+    it('true does real', function (done) {
+        deployGeo.getUserCountry(true).then((ans) => {
+        expect(ans).to.not.equal("--");
+        done();
+      });
+    })
+  });
+})

--- a/test/common/test-geo.js
+++ b/test/common/test-geo.js
@@ -37,7 +37,7 @@ var clearOurKeys = function () {
   localStorage.removeItem('geoLastUpdated');
 };
 
-describe.skip('geo', () => {
+describe('geo', () => {
   before (clearOurKeys);
   after (clearOurKeys);
 

--- a/test/z-ensure-coverage.js
+++ b/test/z-ensure-coverage.js
@@ -2,6 +2,7 @@
 require("../src/always.js");
 require("../src/common/actions.js");
 require("../src/common/client-utils.js");
+require("../src/common/deploy-geo.js");
 require("../src/common/events.js");
 require("../src/common/geo.js");
 require("../src/common/heartbeat/flow.js");


### PR DESCRIPTION

Let's get Country Codes into Heartbeat without WRECKING EVERYTHING.  (And solve one of glind's Q3 goals!  Heros of Heartbeat Medals for Everyone).

Some things:

1.  Heartbeat (github.com/mozilla/self-repair-server)  wants Geo.
2.  Other services have Geo (snippets etc.)
3.  I done broke things yesterday.  (see https://bugzilla.mozilla.org/show_bug.cgi?id=1190500)
4.  bug filed to turn this into a  central service.  I don't really want to wait for it.  https://bugzilla.mozilla.org/show_bug.cgi?id=1190910
5.  locale is a terrible proxy for geo.  EN-US is the worst here.  Only 1/3 of EN-US is actually in the US.  Thus the cake heartbeat stats is a lie.  Also, ps, 10% of the US GEO uses es-MX.  So, I want to report about the US.


Current status:

- Heartbeat is a deployed AWS hosted static site.
- cached geolocation is fine. 
- 30 day caching should have an average (mean) load of like 50 / sec.  Peaks at 150 / sec.  (consistent with snippets).  150,000,000 / 86400 / 30  (caching)  * 3 (peak load, because people don't surf at night). 
- the INITIAL BURST (day 1) is really bad.  3400/sec.  There will also be rhyming (lower) spikes at 30, 60, etc.


Proposals to get over the day one hump (more welcome!):

1.  I do a phased deploy over 30 days.   Unfortunate: It's a static file deploy on AWS, and I don't really have this set up. 
2.  "phase it" in the file... like say "given that it's august, do probably of geo proportional to the day of the month" until it's all rolled out.   This is *doable*, but really gross.
3.  MOAR POWER.  A few more VM's or such for the first month, until it all settles down.  I like this, because I HAVE TO DO NO WORK. 
 4.  Wait until it's in firefox central, let them handle it.  When I take Dave Camp's job in 2114, this will be my first priority :)  So, NO.
 
Asks:
- a project owner (accountable awesomestar) on your side to help me figure out and implement the right solution.  Person:  EOD today, project EOW?

Offers:
- Chris Lonnen's money (or bill User-Advocacy or Engagement) to pay for the servers if we go that way.
- coding on the client side for Gregg
- willingness by Gregg to try to be awesome and take other solutions, and fall back to #2 if needful!

Thanks!

Gregg Lind
User Advocacy
Self-Repair Lead

