### PR TITLE
Launch Plugin Survey

### DIFF
--- a/src/recipes/heartbeat-by-user-first-impression/index.js
+++ b/src/recipes/heartbeat-by-user-first-impression/index.js
@@ -48,7 +48,7 @@ let { hasAny } = require("../../jetpack/array");
 */
 
 const NAME="heartbeat by user v1";
-const VERSION=17;
+const VERSION=18;
 
 let config = {
   lskey : 'heartbeat-by-user-first-impressions',
@@ -229,9 +229,10 @@ let run = function (state, extras) {
   //let engagementUrl =  `https://www.mozilla.org/en-US/firefox/feedback/?updateChannel=${state.updateChannel}&fxVersion=${state.fxVersion}`;  //"http://localhost/enagement.html",
 
   let eUrls = [
-    `https://qsurvey.mozilla.com/s3/Firefox-USE-Survey?source=heartbeat&surveyversion=${VERSION}&updateChannel=${state.updateChannel}&fxVersion=${state.fxVersion}`,
-    `https://qsurvey.mozilla.com/s3/PBM-Survey-Genpop-41?source=heartbeat&surveyversion=${VERSION}&updateChannel=${state.updateChannel}&fxVersion=${state.fxVersion}`,
-    `https://qsurvey.mozilla.com/s3/Heartbeat-Bright-Spots?source=heartbeat&surveyversion=${VERSION}&updateChannel=${state.updateChannel}&fxVersion=${state.fxVersion}`
+    `https://qsurvey.mozilla.com/s3/68ffc1dd1d8b?source=heartbeat&surveyversion=${VERSION}&updateChannel=${state.updateChannel}&fxVersion=${state.fxVersion}`,
+    // `https://qsurvey.mozilla.com/s3/Firefox-USE-Survey?source=heartbeat&surveyversion=${VERSION}&updateChannel=${state.updateChannel}&fxVersion=${state.fxVersion}`,
+    // `https://qsurvey.mozilla.com/s3/PBM-Survey-Genpop-41?source=heartbeat&surveyversion=${VERSION}&updateChannel=${state.updateChannel}&fxVersion=${state.fxVersion}`,
+    // `https://qsurvey.mozilla.com/s3/Heartbeat-Bright-Spots?source=heartbeat&surveyversion=${VERSION}&updateChannel=${state.updateChannel}&fxVersion=${state.fxVersion}`
   ];
 
   let cutBreaks = function (arr, breaks, rng=Math.random()) {
@@ -245,7 +246,7 @@ let run = function (state, extras) {
     }
   };
 
-  let breaks = [.20, .7, 1.0];
+  let breaks = [1.0];
 
   let engagementUrl = cutBreaks(eUrls, breaks);
   if (phConfig.testing && engagementUrl) {
@@ -256,7 +257,7 @@ let run = function (state, extras) {
     local.flow_id,
     local.question_text,
     thankyou,
-    /^en-us/.test(locale) && engagementUrl || null, // only if en-us
+    /^en-/.test(locale) && engagementUrl || null, // only if en-*
     learnmore,  // learn more text
     learnmoreUrl,  // learn more link
     phaseCallback

--- a/test/test-built/test-built-exports.js
+++ b/test/test-built/test-built-exports.js
@@ -48,7 +48,7 @@ describe("built file exports", function () {
         let hb = heartbeat.recipes[0];
         expect(heartbeat.runner.validateConfig(hb)[1]).true();
         expect(hb.name).equal("heartbeat by user v1");
-        expect(hb.version).equal(17);
+        expect(hb.version).equal(18);
       })
       it("has pb mode survey", function () {
         let R = heartbeat.recipes[1];


### PR DESCRIPTION
We need to launch the plugin survey ASAP with the following requirements:
* Survey: https://qsurvey.mozilla.com/s3/68ffc1dd1d8b
* en* locales
* All channels
  * Preferably pass as URL var for segmentation later
    * e.g. "?channel=\<channel\>"
    * No setup needed SG will record any parameter passed
* All OSes