### PR TITLE
 Fix eData reference, PBM Sampling, and queue iOS study

### DIFF
--- a/src/recipes/heartbeat-by-user-first-impression/index.js
+++ b/src/recipes/heartbeat-by-user-first-impression/index.js
@@ -48,7 +48,7 @@ let { hasAny } = require("../../jetpack/array");
 */
 
 const NAME="heartbeat by user v1";
-const VERSION=25;
+const VERSION=26;
 
 let config = {
   lskey : 'heartbeat-by-user-first-impressions',
@@ -106,10 +106,12 @@ let waitedEnough = function (restDays, last, now) {
   * - randomNumber (0,1)
   */
 let shouldRun = function (userstate, config, extras) {
+  let data = eData.data; // Until we have better testing, point directly to data
+
   extras = extras || {};
   let now = extras.when || Date.now();
   let channel = userstate.updateChannel || extras.updateChannel;
-  let lastRun = extras.lastRun || eData.lastRun || 0;
+  let lastRun = extras.lastRun || data.lastRun || 0;
   let locale = (userstate.locale || extras.locale || "unknown").toLowerCase();
 
   config = config || allconfigs[channel];

--- a/src/recipes/ios-promo/config.js
+++ b/src/recipes/ios-promo/config.js
@@ -49,7 +49,11 @@ module.exports = {
     branch: b,
     name: b.name,
     key: 'ios-promo',
+<<<<<<< Updated upstream
     version: 1,
+=======
+    version: 3,
+>>>>>>> Stashed changes
     delay: 60 * 1000 * (1 + 4*Math.random()), // Delay the start by 1-5 minutes
     //phonehomepct: .01*percent
   };}),

--- a/src/recipes/ios-promo/config.js
+++ b/src/recipes/ios-promo/config.js
@@ -49,11 +49,7 @@ module.exports = {
     branch: b,
     name: b.name,
     key: 'ios-promo',
-<<<<<<< Updated upstream
-    version: 1,
-=======
     version: 3,
->>>>>>> Stashed changes
     delay: 60 * 1000 * (1 + 4*Math.random()), // Delay the start by 1-5 minutes
     //phonehomepct: .01*percent
   };}),

--- a/src/recipes/ios-promo/config.js
+++ b/src/recipes/ios-promo/config.js
@@ -21,7 +21,7 @@ let thankyou = "We hope that you enjoy Firefox on your mobile device!";
 let url      = "https://www.mozilla.org/en-US/firefox/mobile-download/";
 let button   = "Get it now";
 let branches = [
-  {
+  /*{ // Lowest performing branches
     name:     "tabs",
     prompt:   "Take your open tabs on the road with you when using Firefox for iOS and Android.",
     thankyou: thankyou,
@@ -34,7 +34,7 @@ let branches = [
     thankyou: thankyou,
     url:      url,
     button:   button
-  },
+  },*/
   {
     name:     "bookmarks",
     prompt:   "Bring your bookmarks & passwords with you. Firefox is now on iOS & Android.",
@@ -57,7 +57,7 @@ module.exports = {
     all: {
       sample: 10 * percent, // will be 1.0 when we launch
       restdays: null,  // irrelevant
-      locales: ["en-US", "en-GB"], // will be en-* locales when we launch
+      locales: ["en-US", "en-GB", "en-ZA"] // All English locales that we support
     }
   }
 };

--- a/src/recipes/ios-promo/index.js
+++ b/src/recipes/ios-promo/index.js
@@ -89,6 +89,7 @@ var setupState = function (key, storage) {
 
   if (! eData.data.flows)   eData.data.flows   = {};
   if (! eData.data.lastRun) eData.data.lastRun = 0;
+  if (! eData.data.uuid)    eData.data.uuid    = uuid(); // used for repeat sample targeting, NOT sent server-side
 
   eData.store();
 
@@ -134,6 +135,9 @@ let isAustralia = function () {
   * - randomNumber (0,1)
   */
 let shouldRun = function (userstate, config, extras) {
+
+  let data = eData.data; // Until we have better testing, point directly to data
+
   config = config || configFile.channels.all;
   if (!config) {
     events.message(NAME, "no-config", {});
@@ -142,7 +146,7 @@ let shouldRun = function (userstate, config, extras) {
   extras = extras || {};
   let now = extras.when || Date.now();
   //let channel = userstate.updateChannel || extras.updateChannel;
-  let lastRun = extras.lastRun || eData.lastRun || 0;
+  let lastRun = extras.lastRun || data.lastRun || 0;
   let locale = (extras.locale || userstate.locale || "unknown").toLowerCase();
   let restdays = config.restdays; // Only run once
   let locales = (config.locales || []).map((x)=>x.toLowerCase());
@@ -177,10 +181,18 @@ let shouldRun = function (userstate, config, extras) {
     return false;
   }
 
+<<<<<<< Updated upstream
   // Sample
   let myRng = extras.randomNumber !== undefined ? extras.randomNumber : Math.random();
 
   if (myRng <= config.sample) {
+=======
+  // Sample based on uuid
+  let myRng  = extras.randomNumber !== undefined ? extras.randomNumber : stringNumberGenerator(data.uuid);
+  //let myRng = extras.randomNumber !== undefined ? extras.randomNumber : Math.random();
+
+  if (myRng <= sample) {
+>>>>>>> Stashed changes
     return true;
   } else {
     events.message(NAME, "bad-random-number", {randomNumber: myRng});

--- a/src/recipes/ios-promo/index.js
+++ b/src/recipes/ios-promo/index.js
@@ -108,6 +108,14 @@ let waitedEnough = function (restDays, last, now) {
   return dayspassed >= restDays ;
 };
 
+// if input is random and long this should return an suitably even hash
+let stringNumberGenerator = function (input, modulo = 100) {
+  let total = 0;
+  for ( var i = 0; i < input.length; i++ ) {
+    total += input.charCodeAt(i);
+  }
+  return (total % modulo) / modulo;
+};
 
 // OH BOY.  This is scary :)
 let isAustralia = function () {
@@ -115,6 +123,7 @@ let isAustralia = function () {
   var gmt_offset = current_date.getTimezoneOffset( ) / 60;
   return  ( -11 <= gmt_offset ) && (gmt_offset <= -8  )
 };
+
 
 /** run or not, given configs?
   *
@@ -151,19 +160,23 @@ let shouldRun = function (userstate, config, extras) {
   let restdays = config.restdays; // Only run once
   let locales = (config.locales || []).map((x)=>x.toLowerCase());
 
+  let geoAus= extras.geoAus || isAustralia();
 
-  let geoOK= extras.geoOK || isAustralia();
+  // bad version.
+  let shortVersion = 1 * (userstate.fxVersion.match(/^[0-9]+/) || 0);
+  if (shortVersion < 41) { // TODO: Represent this in config long-term
+    events.message(NAME, "bad-version", {shortVersion: shortVersion});
+    return false;
+  }
 
-  // All versions
-
-  // Bad locale
+  //// Bad locale
   //console.log({
   //  now: now,
   //  lastRun: lastRun,
   //  locale: locale,
   //  restdays: restdays,
-  //  locales: locales,
-  //  getOK: geoOK
+  //  locales: locales//,
+  //  //geoAus: geoAus
   //});
 
   if (!hasAny(locales, [locale, "*"])) {
@@ -176,23 +189,16 @@ let shouldRun = function (userstate, config, extras) {
     return false;
   }
 
-  if (!geoOK) {
-    events.message(NAME, "bad-geo", {});
-    return false;
+  let sample = config.sample;
+  if (geoAus) { // Override sample if AUS
+    sample = 1.0;
   }
 
-<<<<<<< Updated upstream
-  // Sample
-  let myRng = extras.randomNumber !== undefined ? extras.randomNumber : Math.random();
-
-  if (myRng <= config.sample) {
-=======
   // Sample based on uuid
   let myRng  = extras.randomNumber !== undefined ? extras.randomNumber : stringNumberGenerator(data.uuid);
   //let myRng = extras.randomNumber !== undefined ? extras.randomNumber : Math.random();
 
   if (myRng <= sample) {
->>>>>>> Stashed changes
     return true;
   } else {
     events.message(NAME, "bad-random-number", {randomNumber: myRng});
@@ -207,6 +213,8 @@ let run = function (state, extras = {}) {
   let now = extras.when || Date.now();
   let delay = extras.delay || DELAY;
   let branch = extras.branch || BRANCH.branch;
+
+  let geoAus= extras.geoAus || isAustralia();
 
   eData.data.lastRun = now;
   eData.store();
@@ -257,7 +265,7 @@ let run = function (state, extras = {}) {
   // Add parameters to url
   let fullUrl = `${branch.url}?source=hb&hbv=${VERSION}` +
       `&c=${state.updateChannel}&v=${state.fxVersion}&l=${state.locale}` +
-      `&b=${branch.name}`;
+      `&b=${branch.name}&g=${geoAus}`;
   setTimeout(function() {
     UITour.showHeartbeat(
       branch.prompt,

--- a/src/recipes/pb-mode-survey/index.js
+++ b/src/recipes/pb-mode-survey/index.js
@@ -104,10 +104,12 @@ let waitedEnough = function (restDays, last, now) {
   * - randomNumber (0,1)
   */
 let shouldRun = function (userstate, config, extras) {
+  let data = eData.data; // Until we have better testing, point directly to data
+
   extras = extras || {};
   let now = extras.when || Date.now();
   let channel = userstate.updateChannel || extras.updateChannel;
-  let lastRun = extras.lastRun || eData.lastRun || 0;
+  let lastRun = extras.lastRun || data.lastRun || 0;
   let locale = (userstate.locale || extras.locale || "unknown").toLowerCase();
 
   config = config || allconfigs[channel];
@@ -121,7 +123,7 @@ let shouldRun = function (userstate, config, extras) {
 
   // bad version.
   let shortVersion = 1 * (userstate.fxVersion.match(/^[0-9]+/) || 0);
-  if (shortVersion < 41) {
+  if (shortVersion < 41) { // TODO: Represent this in config long-term
     events.message(NAME, "bad-version", {shortVersion: shortVersion});
     return false;
   }

--- a/src/repairs.js
+++ b/src/repairs.js
@@ -15,6 +15,10 @@
 let repairList = module.exports = [
   //require("./always"),
   require("./recipes/heartbeat-by-user-first-impression"),
+<<<<<<< Updated upstream
   require("./recipes/pb-mode-survey"),
+=======
+  require("./recipes/pb-mode-survey")//,
+>>>>>>> Stashed changes
   //require("./recipes/ios-promo")
 ];

--- a/src/repairs.js
+++ b/src/repairs.js
@@ -15,10 +15,6 @@
 let repairList = module.exports = [
   //require("./always"),
   require("./recipes/heartbeat-by-user-first-impression"),
-<<<<<<< Updated upstream
-  require("./recipes/pb-mode-survey"),
-=======
   require("./recipes/pb-mode-survey")//,
->>>>>>> Stashed changes
   //require("./recipes/ios-promo")
 ];

--- a/test/recipes/test-ios-promo.js
+++ b/test/recipes/test-ios-promo.js
@@ -124,9 +124,8 @@ describe("ios-promo", function () {
             let restdays = C.channels[channel].restdays;
             let now = Date.now();
             let ans = R.shouldRun(state, C.channels[channel],
-              {when: now - 1, lastRun: now - (restdays * days),
-               geoOK: true
-            })
+              {when: now - 1, lastRun: 1}
+            )
             expect(ans, channel).false();
           })
           done();
@@ -142,16 +141,62 @@ describe("ios-promo", function () {
             expect(R.shouldRun(state, null, {
               randomNumber: 99*percent*p,
               when: now,
-              lastRun: 0,
-              geoOK: true
-
+              lastRun: 0
             }), channel + ' 99% of rng is good!').true();
             expect(R.shouldRun(state, null, {
               randomNumber: 101*percent*p,
               when: now,
-              lastRun: now - (restdays * days),
-              geoOK: true
+              lastRun: 0
             }), channel + ' 101% of rng is bad').false();
+          })
+        });
+
+        it('should override the sampling percentage for AUS', function (){
+          allchannels.forEach(function (channel) {
+            let goodLocale = C.channels[channel].locales[0];
+            let state = {fxVersion:  "41.0a1", updateChannel: channel, locale: goodLocale};
+            let p = C.channels[channel].sample;
+            let restdays = C.channels[channel].restdays;
+            let now = Date.now();
+            expect(R.shouldRun(state, null, {
+              randomNumber: 1.0,
+              when: now,
+              lastRun: 0,
+              geoAus: true
+            }), channel + 'Aus is overridden!').true();
+            expect(R.shouldRun(state, null, {
+              randomNumber: 1.0,
+              when: now,
+              lastRun: 0,
+              geoAus: false
+            }), channel + 'non-Aus is not overridden').false();
+          })
+        });
+
+        it('only runs on 41+', function () {
+          let locale = "en-US";
+          let now = Date.now();
+
+          // good!
+          allchannels.forEach(function (channel) {
+
+            let goodLocale = C.channels[channel].locales[0];
+            let restdays = C.channels[channel].restdays;
+            let state = {updateChannel: channel, locale: goodLocale};
+
+            state.fxVersion = "41.0a1";
+            expect(R.shouldRun(state, null, {
+              randomNumber: 0,
+              when: now,
+              lastRun: 0
+            }), channel + " version okay").true();
+
+            state.fxVersion = "40.0a1";
+            expect(R.shouldRun(state, null, {
+              randomNumber: 0,
+              when: now,
+              lastRun: 0
+            }), channel + " version bad").false();
           })
         });
 
@@ -165,32 +210,11 @@ describe("ios-promo", function () {
               expect(R.shouldRun(state, null, {
                 randomNumber: 0,
                 when: now,
-                lastRun: 0,
-                geoOK: true
+                lastRun: 0
               }), channel + " " + locale).true();
             })
           })
         })
-
-        it('refuses bad geo', function (done) {
-          let channel = Object.keys(C.channels)[0];
-          let locale = C.channels[channel].locales[0];
-          let observed = events.observe(R.name, function (msg, data) {
-            if (msg === "bad-geo") {
-              done();
-              events.unobserve(observed);
-            }
-          })
-          let now = Date.now();
-          let restdays = C.channels[channel].restdays;
-          let state = {fxVersion:  "41.0a1", updateChannel: channel, locale: locale};
-          expect(R.shouldRun(state, null, {
-            randomNumber: 0,
-            when: now,
-            lastRun: 0,
-            geoOK: false
-          }), channel + " " + locale).true();
-        });
 
         it('refuses bad locale', function (done) {
           allchannels.forEach(function (channel) {
@@ -207,8 +231,7 @@ describe("ios-promo", function () {
             expect(R.shouldRun(state, null, {
               randomNumber: 0,
               when: now,
-              lastRun: now - (restdays * days),
-              geoOK: true
+              lastRun: 0
             }), channel + ' bad locale is bad').false();
           })
           done();
@@ -223,7 +246,7 @@ describe("ios-promo", function () {
             restdays: 0,
             locales: ["*"]
           },
-          {lastRun: 0, geoOK: true}
+          {lastRun: 0}
           )).to.be.true();
         });
 
@@ -243,7 +266,7 @@ describe("ios-promo", function () {
               restdays: 0
             }
           };
-          let extras = {lastRun: 0, when: Date.now(), geoOK: true};
+          let extras = {lastRun: 0, when: Date.now()};
           it("should respect good locales", function () {
             let userstate = {fxVersion:  "41.0a1", locale: "it-IT"};
             let config = genConfig(['ru-RU', 'it-IT']);
@@ -324,7 +347,6 @@ describe("ios-promo", function () {
           }
         );
       });
-
     });
 
     describe("testable functions", function () {

--- a/test/test-built/test-built-exports.js
+++ b/test/test-built/test-built-exports.js
@@ -56,21 +56,12 @@ describe("built file exports", function () {
         expect(R.name).equal("pb-mode-survey");
         expect(R.version).equal(3);
       })
-<<<<<<< Updated upstream
-      //it("has ios promo, right version", function () {
-      //  let ios = heartbeat.recipes[2];
-      //  expect(heartbeat.runner.validateConfig(ios)[1]).true();
-      //  expect(ios.name).equal("ios-promo");
-      //  expect(ios.version).equal(1);
-      //})
-=======
       it("has ios promo, right version", function () {
         let ios = heartbeat.recipes[2];
         expect(heartbeat.runner.validateConfig(ios)[1]).true();
         expect(ios.name).equal("ios-promo");
         expect(ios.version).equal(3);
       })
->>>>>>> Stashed changes
     })
   })
 

--- a/test/test-built/test-built-exports.js
+++ b/test/test-built/test-built-exports.js
@@ -48,20 +48,29 @@ describe("built file exports", function () {
         let hb = heartbeat.recipes[0];
         expect(heartbeat.runner.validateConfig(hb)[1]).true();
         expect(hb.name).equal("heartbeat by user v1");
-        expect(hb.version).equal(25);
+        expect(hb.version).equal(26);
       });
       it("has pb mode survey", function () {
         let R = heartbeat.recipes[2];
         expect(heartbeat.runner.validateConfig(R)[1]).true();
         expect(R.name).equal("pb-mode-survey");
-        expect(R.version).equal(2);
+        expect(R.version).equal(3);
       })
+<<<<<<< Updated upstream
       //it("has ios promo, right version", function () {
       //  let ios = heartbeat.recipes[2];
       //  expect(heartbeat.runner.validateConfig(ios)[1]).true();
       //  expect(ios.name).equal("ios-promo");
       //  expect(ios.version).equal(1);
       //})
+=======
+      it("has ios promo, right version", function () {
+        let ios = heartbeat.recipes[2];
+        expect(heartbeat.runner.validateConfig(ios)[1]).true();
+        expect(ios.name).equal("ios-promo");
+        expect(ios.version).equal(3);
+      })
+>>>>>>> Stashed changes
     })
   })
 


### PR DESCRIPTION
We need to accomplish 3 tasks
1) Fix the references to eData.lastRun to be eData.data.lastRun
2) Make sure PBM is only for versions >= 41
3) Get the iOS study ready for quick redeployment