### PR TITLE
deprecate localStorage for client data / persistent state.

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,3 +187,9 @@ https://self-repair.mozilla.org/en-US/repair/?{"runner":{"alwaysRun":true}}
 ## Issues / Bugs
 
 For now, github issues at https://github.com/mozilla/self-repair-server/issues
+
+
+## Population
+
+- runs once per session, about 5 minutes after startup.
+- because of issue #212, people who clear localStorage won't see heartbeat things.  This includes users of some addons, and those with some privacy sensitive settings.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "self-repair-server",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "description": "Server package for Mozilla self-repair-server.",
   "main": "",
   "repository": {
@@ -25,6 +25,7 @@
     "karma-webpack": "^1.5.0",
     "messageformat": "^0.3.0-1",
     "mocha": "^2.1.0",
+    "mock-localstorage": "^0.1.3",
     "opener": "^1.4.1",
     "scriptjs": "^2.5.7",
     "serve": "^1.4.0",

--- a/scripts/locale_base/index.html
+++ b/scripts/locale_base/index.html
@@ -7,7 +7,7 @@
 <script inline src="./index.js"></script>
 <script>
   if (window.heartbeat) {
-    heartbeat.main(heartbeat.recipes);
+    heartbeat.main(heartbeat.recipes).then(new Function(), new Function());
   }
 </script>
 

--- a/src/common/personinfo.js
+++ b/src/common/personinfo.js
@@ -33,7 +33,7 @@ let navigatorInfo = function (navigator = window.navigator) {
 
   let plugins = {};
   Object.keys(navigator.plugins).filter((p)=>!/[0-9]+/i.test(p)).forEach(
-    (p) => plugins[p]=navigator.plugins[p].version
+    (p) => plugins[p] = navigator.plugins[p].version
   )
 
   return {
@@ -167,8 +167,32 @@ let personinfo = function (tour, aConfig) {
   });
 };
 
+const PERSISTENT_LOCALSTORAGE_KEY = "localStorageUsed";
+function tryLocalStorage (store = localStorage) {
+  try {
+    var haveChecked = JSON.parse(store.getItem(PERSISTENT_LOCALSTORAGE_KEY) || 0);
+    if (!haveChecked || haveChecked < 2) {
+      store.setItem(PERSISTENT_LOCALSTORAGE_KEY, ++haveChecked);
+    }
+  } catch (e) {
+    store.setItem(PERSISTENT_LOCALSTORAGE_KEY, 1);
+  }
+};
+
+function isLocalStoragePersistent (store = localStorage) {
+  try {
+    var haveChecked = store.getItem(PERSISTENT_LOCALSTORAGE_KEY) || 0;
+    return JSON.parse(haveChecked) >= 2;
+  } catch (e) {
+    return false;
+  }
+};
+
 exports.personinfo = personinfo;
 exports.navigatorInfo = navigatorInfo;
+exports.tryLocalStorage = tryLocalStorage;
+exports.isLocalStoragePersistent = isLocalStoragePersistent;
+
 
 /*
 

--- a/src/recipes/heartbeat-by-user-first-impression/config.js
+++ b/src/recipes/heartbeat-by-user-first-impression/config.js
@@ -12,7 +12,7 @@
 
 "use strict";
 
-const VERSION=40;
+const VERSION=50;
 
 const million = Math.pow(10,6);
 const thousand = Math.pow(10,3);

--- a/test/common/test-personinfo.js
+++ b/test/common/test-personinfo.js
@@ -17,6 +17,8 @@
 let { expect } = require("chai");
 let personinfo = require("../../src/common/personinfo");
 
+var MockLocalStorage = require('mock-localstorage');
+
 require("../utils").shimTodo(it);
 
 function ShimTour () {
@@ -35,6 +37,20 @@ function ShimTour () {
 }
 
 describe("personalinfo", function () {
+  describe('module', () => {
+    let wanted = [ "config", "personinfo", "navigatorInfo", "tryLocalStorage", "isLocalStoragePersistent" ];
+    it('export keys, as methods', ()=>{
+      expect(personinfo).keys(wanted);
+      wanted.forEach((k)=>{
+        if (k == "config") {
+          expect(personinfo[k], "${k} is object").to.be.an("object");
+        } else {
+          expect(personinfo, "${k} is method").respondTo(k);
+        }
+      })
+    })
+  });
+
   describe ("fakes and shims", () => {
     it('will flag as timeout and incomplete, but resolve', function (done) {
       let aConfig = {
@@ -100,13 +116,49 @@ describe("personalinfo", function () {
         }
       )
     })
-
   });
 
-  it("personalinfo exists", function () {
-    expect(personinfo.personinfo).to.be.a("function");
+  it.todo("figure out how to test this on a tour-priv'd page", ()=>{});
+
+  describe("persistent localStorage", function () {
+    const PERSISTENT_LOCALSTORAGE_KEY = "localStorageUsed";
+
+    it("tryLocalStorage and isLocalStoragePersistent works", function () {
+      let store = new MockLocalStorage();
+      let get = () => {
+        let v = store.getItem(PERSISTENT_LOCALSTORAGE_KEY);
+        if (v !== undefined) {
+          return JSON.parse(v);
+        } else {
+          return v;
+        }
+      }
+      let set = (val) => store.setItem(PERSISTENT_LOCALSTORAGE_KEY, val);
+
+      expect(get(store), "should be undefined at first").to.equal(undefined);
+      expect(personinfo.isLocalStoragePersistent(store), "isPersistent false at 0").to.equal(false);
+
+      personinfo.tryLocalStorage(store);
+      expect(get(store), "then 1").to.equal(1);
+      expect(personinfo.isLocalStoragePersistent(store), "isPersistent false at 1").to.equal(false);
+
+      personinfo.tryLocalStorage(store);
+      expect(get(store), "then 2").to.equal(2);
+      expect(personinfo.isLocalStoragePersistent(store), "isPersistent true at 2").to.equal(true);
+
+      personinfo.tryLocalStorage(store);
+      expect(get(store), "then 2 forever!").to.equal(2);
+      expect(personinfo.isLocalStoragePersistent(store), "isPersistent true at 2").to.equal(true);
+
+      // set up for garbage;
+      store.clear();
+      set("{some jank");
+      expect(personinfo.isLocalStoragePersistent(store), "isPersistent false with garbage").to.equal(false);
+
+      personinfo.tryLocalStorage(store);
+      expect(get(store), "if old value was garbage (wrong type), go to 1").to.equal(1);
+
+    });
   })
 
-
-  it.todo("figure out how to test this on a tour-priv'd page", ()=>{});
 });

--- a/test/test-built/test-built-exports.js
+++ b/test/test-built/test-built-exports.js
@@ -49,8 +49,30 @@ describe("built file exports", function () {
       let hb = heartbeat.recipes[0];
       expect(heartbeat.runner.validateConfig(hb)[1]).true();
       expect(hb.name).equal("heartbeat by user v1");
-      expect(hb.version).equal(40);
+      expect(hb.version).equal(50);
     });
+  })
+
+  describe("main", function () {
+    let heartbeat = window.heartbeat;
+    it("will reject if localStorage is not persistent", function (done) {
+      localStorage.clear(); // bam.
+      expect(heartbeat.personinfo.isLocalStoragePersistent()).to.be.false();
+      heartbeat.main([]).then(
+        (e) => {done(new Error("should reject as invalid"))},
+        (e) => {done()}
+      );
+    })
+    it("will resolve if localStorage is ok", function (done) {
+      localStorage.clear(); // bam.
+      heartbeat.personinfo.tryLocalStorage();
+      heartbeat.personinfo.tryLocalStorage();
+      expect(heartbeat.personinfo.isLocalStoragePersistent()).to.be.true();
+      heartbeat.main([]).then(
+        (e) => {done()},
+        (e) => {done(new Error("should have resolved true"))}
+      );
+    })
   })
 
   describe('time bombs', function () {


### PR DESCRIPTION
Issue:  localStorage
- overflows (unpredictably)
- is easy to clear (using some firefox settings and addons)

Ideas:
1.  test if there is persistent data storage available.  React accordingly.  
2.  use cookies on first startup.
3.  switch to an entirely 'smart server-driven' architecture, where all storage is in cloud.
4.  expose some get/set pref API to Tour, which is 'less erasable'.


Each of these introduces new problems and trade-offs.
