### PR TITLE
better linting of allowed filtering fields in survey deploy config

### DIFF
--- a/src/recipes/heartbeat-by-user-first-impression/config.js
+++ b/src/recipes/heartbeat-by-user-first-impression/config.js
@@ -12,7 +12,7 @@
 
 "use strict";
 
-const VERSION=35;
+const VERSION=36;
 
 const million = Math.pow(10,6);
 const thousand = Math.pow(10,3);
@@ -34,6 +34,18 @@ const days = 24 * 60 * 60 * 1000;
   * 6.  If you would rather specify rule breaks in a 'proportional' style,
   *     use `asBreaks([50,25,25])` => [.50,.75,1]
   */
+
+
+const filterFields = [
+  "updateChannel",
+  "fxVersion",
+  "locale",
+  "country",
+  "defaultBrowser",
+  "searchEngine",
+  "syncSetup"
+];
+
 
 const engagementRules = [
   // en, aurora.
@@ -143,5 +155,6 @@ module.exports = {
       locales: supportedLocales
     }
   },
-  supportedLocales: supportedLocales
+  supportedLocales: supportedLocales,
+  filterFields
 };

--- a/test/recipes/test-heartbeat-by-user-first-impression.js
+++ b/test/recipes/test-heartbeat-by-user-first-impression.js
@@ -62,7 +62,7 @@ function okEngagementSpec(spec, name) {
 
 describe("hb config", function () {
   it("has right exports", function () {
-    let expected = ['engagementRules',"VERSION",'sampling', 'supportedLocales'];
+    let expected = ['engagementRules',"filterFields","VERSION",'sampling', 'supportedLocales'];
     expect(C).keys(expected);
   });
 
@@ -73,6 +73,14 @@ describe("hb config", function () {
       for (let k=0; k<rules.length; k++) {
         okEngagementSpec(rules[k],k);
       }
+    })
+    it("has rules that only use allowed fields", function (){
+      let rules = C.engagementRules;
+      rules.map((r) => {
+
+        let allOk = Object.keys(r.rule).every((k)=>C.filterFields.indexOf(k)>=0);
+        expect(allOk, "at least one key not allowed in filterFields => "+Object.keys(r.rule)).to.be.true()
+      })
     })
   })
 });

--- a/test/test-built/test-built-exports.js
+++ b/test/test-built/test-built-exports.js
@@ -49,7 +49,7 @@ describe("built file exports", function () {
       let hb = heartbeat.recipes[0];
       expect(heartbeat.runner.validateConfig(hb)[1]).true();
       expect(hb.name).equal("heartbeat by user v1");
-      expect(hb.version).equal(35);
+      expect(hb.version).equal(36);
     });
   })
 


### PR DESCRIPTION
Should:  only allow feels that are in the person info packet.  

Maybe export those?  Creates a gross dependency of config onto personinfo! 

