### PR TITLE
Prove / lint that filters are in a 'restrictive' order.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "self-repair-server",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Server package for Mozilla self-repair-server.",
   "main": "",
   "repository": {

--- a/test/test-built/test-deployed-survey-config.js
+++ b/test/test-built/test-deployed-survey-config.js
@@ -13,23 +13,18 @@
 
 "use strict";
 
-/* this code mostly exists
-   - for coverage sake
-   - catch when new actions are added
-*/
 let { expect } = require("chai");
 let rulesMod = require("../../src/common/rules");
-
 
 let C = require("../../src/recipes/heartbeat-by-user-first-impression/config");
 let U = require("../../src/recipes/heartbeat-by-user-first-impression/utils");
 
 
-// idea... print out the survey audit?
+let {isRe, regexReplacer, isConfigSorted} = require('../utils');
 
 let locales = ['en-us','en-uk', 'es-mx', 'zh-cn', 'de'];
 let versions = ['46.0.1','47.0.1'];
-let channels = ['aurora','release', 'beta', 'nightly']
+let channels = ['aurora','release', 'beta', 'nightly'];
 
 function genProducts() {
   let out = [];
@@ -45,28 +40,9 @@ function genProducts() {
   return out
 }
 
-/*
-  [a,b],
-  [c,d],
-  [e,f]
-
-  a c e
-  a c f
-  a d e
-  a d f
-
-
-  for k in _gen([c,d], [e,f]):
-    _out.push([a] + k)
-
-
-*/
-
-
-
+// for every possible combo, see which rule matches, and what urls there are!
 let possibles = genProducts();
 
-// for every possible combo, see which rule matches, and what urls there are!
 
 function isRe (thing) {
   return Object.prototype.toString.call( thing ) == "[object RegExp]"
@@ -76,6 +52,11 @@ function regexReplacer (key, value) {
   if (isRe(value)) return '' + value;
   return value;
 }
+
+
+
+
+
 
 describe("Survey Rules Report", function () {
   var getEngagementUrl = U.getEngagementUrl;
@@ -120,6 +101,10 @@ ${JSON.stringify(C.engagementRules, regexReplacer, 2)}
 `)
 
   it ("should report", ()=>expect(true).to.be.true());
+
+  it ("should be sorted restrictive rules first", function () {
+    expect(isConfigSorted(C.engagementRules)).to.be.true();
+  })
 
 })  // end of test.
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -20,3 +20,60 @@ exports.shimTodo = function (itFn) {
 };
 
 exports.uuid = require('uuid');
+
+
+
+function isRe (thing) {
+  return Object.prototype.toString.call( thing ) == "[object RegExp]"
+}
+
+function regexReplacer (key, value) {
+  if (isRe(value)) return '' + value;
+  return value;
+}
+
+
+// rule sorting
+function _normalizeRule(r) {
+  let out = {};
+  for (let x in r) {out[x] = r[x].toString()}
+  return out;
+}
+
+/*
+  _ruleInRule({a:1},{a:1,b:2})  T
+  _ruleInRule({a:1},{a:2,b:2})  F
+  _ruleInRule({a:1,c:1},{a:1,b:2})  F
+  _ruleInRule({a:1,c:1},{a:1,b:2, c:1}) T
+*/
+function _ruleInRule(r1, r2) {
+  return Object.keys(r1).map((k)=>r2[k] == r1[k]).every(Boolean);
+  // O: |r1| * |r2|
+  // for part in r1;
+  //   is r1 in r2?
+  //
+  // return false
+}
+
+function _rulesSorted(rules) {
+  // this is a O(|array|)^2, hopefully not that gross for most things
+  for (let ii = 1;  ii < rules.length; ii++) {   // start a 1
+    for (let jj = 0; jj < ii; jj ++) {           // 0 to ii - 1
+        if (_ruleInRule(rules[ii], rules[jj])) {
+          throw new Error(`wrong order ${JSON.stringify(rules[ii])}, ${JSON.stringify(rules[jj])}`);
+        }
+    }
+  }
+  return true
+}
+
+function isConfigSorted(rulesOriginal) {
+  // we want restrictive first, so reverse the list.
+  // on the normalized rules
+  return _rulesSorted(rulesOriginal.reverse().map((x)=>_normalizeRule(x.rule)))
+}
+
+
+exports.isRe = isRe;
+exports.regexReplacer = regexReplacer;
+exports.isConfigSorted = isConfigSorted;


### PR DESCRIPTION
Claim: showing that the survey deployment rules are in a topo sorted order is the best we can do here.

Complications:  regexes, probabilities, etc.  We cant show if geo=us or channel=release is more restrictive without probabilities.  we can say they are indeterminate