### PR TITLE
Switch geo detection from geo.moz.org to MLS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "self-repair-server",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Server package for Mozilla self-repair-server.",
   "main": "",
   "repository": {
@@ -27,7 +27,6 @@
     "mocha": "^2.1.0",
     "mock-localstorage": "^0.1.3",
     "opener": "^1.4.1",
-    "scriptjs": "^2.5.7",
     "serve": "^1.4.0",
     "shelljs": "^0.5.1",
     "thirdparty": "file:thirdparty",

--- a/src/common/geo.js
+++ b/src/common/geo.js
@@ -15,30 +15,23 @@
 
 "use strict";
 
-var $script = require("scriptjs");
-
-var GEO_URL = 'https://geo.mozilla.org/country.js';
+// https://github.com/mozilla/self-repair-server/issues/239
+var GEO_URL = 'https://location.services.mozilla.com/v1/country?key=fcce8909-53a6-4d26-83da-e822cdf4ac13';
 var GEO_CACHE_DURATION = 1000 * 60 * 60 * 24 * (30 + Math.random()); // 30-ish days
 
 function downloadUserCountry() {
-  return new Promise(function (resolve, reject) {
-    $script(GEO_URL, 'geo');
-    $script.ready('geo', function() {
-      try {
-        if (typeof geoip_country_code == "undefined") {
-          throw(new Error("geo: unable to load js file."))
-        }
-        gSnippetsMap.set('geoCountry', geoip_country_code());
-        gSnippetsMap.set('geoLastUpdated', new Date());
-        resolve();
-      } catch (e) {
-        reject(e);
-        // Most likely failed to load JS file. Continue on without us,
-        // we'll try again next time.
-      }
-      resolve();
-    });
-  });
+  return fetch(GEO_URL).then((response) => {
+    /*
+    {
+      "country_code": "US",
+      "country_name": "United States",
+      "fallback": "ipf"
+    }*/
+    return response.json()
+  }).then( (data) => {
+    gSnippetsMap.set('geoCountry', data["country_code"]);
+    gSnippetsMap.set('geoLastUpdated', new Date());
+  })
 }
 
 // Check whether we have the user's country stored and if it is still valid.

--- a/src/recipes/heartbeat-by-user-first-impression/config.js
+++ b/src/recipes/heartbeat-by-user-first-impression/config.js
@@ -12,7 +12,7 @@
 
 "use strict";
 
-const VERSION=50;
+const VERSION=51;
 
 const million = Math.pow(10,6);
 const thousand = Math.pow(10,3);

--- a/test/test-built/test-built-exports.js
+++ b/test/test-built/test-built-exports.js
@@ -49,7 +49,7 @@ describe("built file exports", function () {
       let hb = heartbeat.recipes[0];
       expect(heartbeat.runner.validateConfig(hb)[1]).true();
       expect(hb.name).equal("heartbeat by user v1");
-      expect(hb.version).equal(50);
+      expect(hb.version).equal(51);
     });
   })
 


### PR DESCRIPTION
@gregglind this also references #181. We talked about various long term options to expose country data from a central place inside the browser. But for the short term we want to shut down geo.mozilla.org and switch everyone to MLS.

The MLS API is documented at https://mozilla.github.io/ichnaea/api/region.html, though the simplest  way is to do a GET request, like:

curl https://location.services.mozilla.com/v1/country?key=fcce8909-53a6-4d26-83da-e822cdf4ac13

and get a status code 200 JSON response, with a body of:

{
    "country_code": "US",
    "country_name": "United States",
    "fallback": "ipf"
}

In failure cases 4xx and 5xx status codes can be returned, not all of them necessarily containing JSON in the body.

The API key here is only used to identify the consuming service/website, so we can collect metrics about their individual usage and attribute back problems to the right caller. The key in the curl example is meant to be used by self-repair. It can be put into a public repo and be shared across dev/stage/prod sites.

For another code example of the snippets service switching over see:

https://github.com/mozilla/snippets-service/pull/143/files#diff-3adb3669370af06c37adc916ba7b7c3cL398